### PR TITLE
Fix compile failure

### DIFF
--- a/hspkcs11.cabal
+++ b/hspkcs11.cabal
@@ -27,6 +27,7 @@ library
     Default-language:  Haskell2010
 
 executable pkcs11-tests
+    build-tools:   c2hs
     main-is:            Test.hs
     Include-dirs: include
     other-modules:      System.Crypto.Pkcs11


### PR DESCRIPTION
Without this, recent cabal version will fail to build this due to

```
cabal: The program 'c2hs' version >=0.15 is required but it could not be found.
```